### PR TITLE
updated plotting options to be more informative as well as some refactoring

### DIFF
--- a/src/gui_tabs/automationLaserTab.py
+++ b/src/gui_tabs/automationLaserTab.py
@@ -1,13 +1,11 @@
 import tkinter as tk
 import tkinter.filedialog
 
-import pandas
 import pandas as pd
 from PIL import Image, ImageTk
 import os
 import sys
 import threading
-import multiprocessing
 import queue
 from src.gui_tabs.graph_box import GraphBox
 import time
@@ -215,8 +213,6 @@ class AutomationTab:
         if self.graph:
             self.graph.__del__()
         self.graph = GraphBox(self.distanceInput.get(), self.graph_selector_var.get())
-        # Create a multiprocessing Queue to be able to pass images back and forth
-        self.image_queue = self.manager.Queue()
         # Reset all data structures
         self.graph.amplitude_data = []
         self.graph.phase_data = []
@@ -388,9 +384,7 @@ class AutomationTab:
                 self.update_automation_textbox(dataFrame)
 
                 # Update graph data
-                pickle_loc = self.graph.PICKLE_FILE_LOCATION +"_"+self.spacing_selector_var.get() +".pickle"
-                pd.to_pickle(dataFrame, pickle_loc)
-                self.graph.data_queue.put_nowait(pickle_loc)
+                self.graph.queue_plot_update(dataFrame, self.spacing_selector_var.get())
                 print("Sent new data to plotting process")
 
             except queue.Empty:

--- a/src/gui_tabs/automationLaserTab.py
+++ b/src/gui_tabs/automationLaserTab.py
@@ -18,7 +18,7 @@ SAMPLE_OPTIONS_PATH = os.path.join(PROJECT_ROOT, "res", "Sample Options.csv")
 
 class AutomationTab:
     def __init__(self, parent, instruments, main_gui):
-        self.graph = GraphBox(1,"Default")
+        self.graph = GraphBox(1,"TrendLive")
         self.parent = parent
         self.instruments = instruments
         self.setup_ui()
@@ -136,8 +136,8 @@ class AutomationTab:
         self.stepCountInput.grid(row=2, column=1, padx=10, pady=10)
         self.stepCountLabel.grid(row=2, column=0, padx=10, pady=10)
 
-        graph_selector_options = ["Default", "Candlestick", "TrendLive", "TrajectoryLive", "DualPanelLive"]
-        self.graph_selector_var = tk.StringVar(output_frame, "Default")
+        graph_selector_options = ["TrendLive", "Legacy", "Candlestick", "TrajectoryLive", "DualPanelLive"]
+        self.graph_selector_var = tk.StringVar(output_frame, "TrendLive")
         self.graph_selector = tk.OptionMenu(output_frame, self.graph_selector_var, *graph_selector_options)
         self.graph_selector.grid(row=2, column=2, padx=10, pady=10)
 
@@ -242,11 +242,8 @@ class AutomationTab:
         self.laser_settings = (freq, amp, offset, timeStep, stepCount, spot_distance, spacing)
 
 
-        self.startMeasurements["state"] = "disabled"
-        self.endMeasurements["state"] = "normal"
+        self._set_measurement_controls(running=True)
         self.stepCountInput["state"] = "normal"
-        self.fileStorageButton["state"] = "disabled"
-        self.fileStorageLabel["state"] = "disabled"
         self.automationTxtBx.insert('1.0', f"Starting Automation...\n")
         self.automationTxtBx.insert('1.0', f"Time Step: {timeStep}s\n")
         self.automationTxtBx.insert('1.0', f"Step Count: {stepCount}\n")
@@ -257,6 +254,18 @@ class AutomationTab:
         if begin == True:
             threading.Thread(target=self.instruments.automatic_measuring, 
                              args=(self.laser_settings, filepath, False)).start()
+
+    def _set_measurement_controls(self, running):
+        if running:
+            self.startMeasurements["state"] = "disabled"
+            self.endMeasurements["state"] = "normal"
+            self.fileStorageButton["state"] = "disabled"
+            self.fileStorageLabel["state"] = "disabled"
+        else:
+            self.endMeasurements["state"] = "disabled"
+            self.startMeasurements["state"] = "normal"
+            self.fileStorageButton["state"] = "normal"
+            self.fileStorageLabel["state"] = "normal"
 
 
     def end_automation(self):
@@ -285,10 +294,7 @@ class AutomationTab:
             self.parent.after(100)  # Give time for automation to clean up
 
         # Reset all GUI elements
-        self.endMeasurements["state"] = "disabled"
-        self.startMeasurements["state"] = "normal"
-        self.fileStorageButton["state"] = "normal"
-        self.fileStorageLabel["state"] = "normal"
+        self._set_measurement_controls(running=False)
         self.timePerStepInput["state"] = "normal"
         self.stepCountInput["state"] = "normal"
 
@@ -374,6 +380,10 @@ class AutomationTab:
 """)
 
     def schedule_automation_update(self):
+        if self.instruments.automation_status == "completed" and self.startMeasurements["state"] == "disabled":
+            self._set_measurement_controls(running=False)
+            self.automationTxtBx.insert('1.0', "Automation completed. Ready for new measurement.\n")
+
         if not self.instruments.automationQueue.empty():
             print("Automation queue not empty")
             try:

--- a/src/gui_tabs/automationLaserTab.py
+++ b/src/gui_tabs/automationLaserTab.py
@@ -136,7 +136,7 @@ class AutomationTab:
         self.stepCountInput.grid(row=2, column=1, padx=10, pady=10)
         self.stepCountLabel.grid(row=2, column=0, padx=10, pady=10)
 
-        graph_selector_options = ["Default", "Candlestick"]
+        graph_selector_options = ["Default", "Candlestick", "TrendLive", "TrajectoryLive", "DualPanelLive"]
         self.graph_selector_var = tk.StringVar(output_frame, "Default")
         self.graph_selector = tk.OptionMenu(output_frame, self.graph_selector_var, *graph_selector_options)
         self.graph_selector.grid(row=2, column=2, padx=10, pady=10)

--- a/src/gui_tabs/graph_box.py
+++ b/src/gui_tabs/graph_box.py
@@ -8,7 +8,13 @@ from matplotlib import pyplot as plt
 from PIL import Image
 
 
-SUPPORTED_PLOTS = {"Default", "Candlestick"}
+SUPPORTED_PLOTS = {
+    "Default",
+    "Candlestick",
+    "TrendLive",
+    "TrajectoryLive",
+    "DualPanelLive",
+}
 
 
 def _prepare_data(payload):
@@ -34,6 +40,11 @@ def _figure_to_image(fig):
     image = Image.open(buf).copy()
     buf.close()
     return image
+
+
+def _apply_frequency_scale(ax, spacing_type):
+    if spacing_type == "logspace":
+        ax.set_xscale("log")
 
 
 def _render_default_plot(data, spacing_type):
@@ -70,8 +81,7 @@ def _render_default_plot(data, spacing_type):
     ax1.set_ylabel("Phase (rad)", color="blue")
     ax2.set_ylabel("Diffusivity", color="green")
 
-    if spacing_type == "logspace":
-        ax1.set_xscale("log")
+    _apply_frequency_scale(ax1, spacing_type)
 
     ax1.set_title("Phase and Diffusivity vs Frequency")
     ax1.grid(True)
@@ -118,8 +128,8 @@ def _render_candlestick_plot(data, spacing_type):
     else:
         candle_width = max(abs(frequencies[0]) * 0.05, 1.0)
 
-    up_color = "#2ca02c"
-    down_color = "#d62728"
+    candle_line = "#1f3a5f"
+    candle_fill = "#7ea3cc"
 
     for freq in frequencies:
         open_val = float(opens.loc[freq])
@@ -127,9 +137,7 @@ def _render_candlestick_plot(data, spacing_type):
         high_val = float(highs.loc[freq])
         low_val = float(lows.loc[freq])
 
-        color = up_color if close_val >= open_val else down_color
-
-        ax.vlines(freq, low_val, high_val, color=color, linewidth=1.5, zorder=1)
+        ax.vlines(freq, low_val, high_val, color=candle_line, linewidth=1.5, zorder=1)
 
         body_bottom = min(open_val, close_val)
         body_height = abs(close_val - open_val)
@@ -140,23 +148,18 @@ def _render_candlestick_plot(data, spacing_type):
             (freq - candle_width / 2, body_bottom),
             candle_width,
             body_height,
-            facecolor=color,
-            edgecolor=color,
+            facecolor=candle_fill,
+            edgecolor=candle_line,
             alpha=0.7,
             zorder=2,
         )
         ax.add_patch(rect)
 
-    up_proxy = plt.Line2D([0], [0], color=up_color, lw=6)
-    down_proxy = plt.Line2D([0], [0], color=down_color, lw=6)
-    ax.legend(
-        [up_proxy, down_proxy],
-        ["Green: Close >= Open", "Red: Close < Open"],
-        loc="upper right",
-    )
+    wick_proxy = plt.Line2D([0], [0], color=candle_line, lw=2)
+    body_proxy = plt.Rectangle((0, 0), 1, 1, facecolor=candle_fill, edgecolor=candle_line, alpha=0.7)
+    ax.legend([wick_proxy, body_proxy], ["Wick: Low to High", "Body: Open to Close"], loc="upper right")
 
-    if spacing_type == "logspace":
-        ax.set_xscale("log")
+    _apply_frequency_scale(ax, spacing_type)
 
     ax.set_title("Candlestick Phase vs Frequency")
     ax.set_xlabel("Frequency (Hz)")
@@ -165,6 +168,124 @@ def _render_candlestick_plot(data, spacing_type):
     fig.tight_layout()
 
     return fig
+
+
+def _render_trend_live_plot(data, spacing_type):
+    fig = plt.figure(figsize=(8, 8))
+    ax = fig.gca()
+
+    grouped = data.groupby("FrequencyIn")["PhaseOut"]
+    median_phase = grouped.median().sort_index()
+    q1 = grouped.quantile(0.25).reindex(median_phase.index)
+    q3 = grouped.quantile(0.75).reindex(median_phase.index)
+
+    ax.plot(median_phase.index, median_phase.values, color="#1f77b4", linewidth=2, label="Median Phase")
+    ax.fill_between(median_phase.index, q1.values, q3.values, color="#1f77b4", alpha=0.2, label="IQR (25-75%)")
+
+    latest = data.iloc[-1]
+    ax.scatter(
+        [latest["FrequencyIn"]],
+        [latest["PhaseOut"]],
+        color="#d62728",
+        s=80,
+        marker="o",
+        label="Latest Measurement",
+        zorder=3,
+    )
+
+    _apply_frequency_scale(ax, spacing_type)
+    ax.set_title("Live Phase Trend with IQR Band")
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel("Phase (rad)")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right")
+    fig.tight_layout()
+    return fig
+
+
+def _render_trajectory_live_plot(data, spacing_type):
+    fig = plt.figure(figsize=(8, 8))
+    ax = fig.gca()
+
+    points = data[["FrequencyIn", "PhaseOut"]].to_numpy()
+    count = len(points)
+    if count == 1:
+        ax.scatter(points[:, 0], points[:, 1], color="#ff7f0e", s=90)
+    else:
+        for idx in range(count - 1):
+            alpha = 0.15 + 0.75 * ((idx + 1) / (count - 1))
+            ax.plot(
+                points[idx:idx + 2, 0],
+                points[idx:idx + 2, 1],
+                color="#ff7f0e",
+                linewidth=2,
+                alpha=alpha,
+            )
+        ax.scatter(points[:-1, 0], points[:-1, 1], color="#ffbe7d", s=20, alpha=0.35, label="Older Measurements")
+        ax.scatter(points[-1, 0], points[-1, 1], color="#d62728", s=90, label="Latest Measurement", zorder=3)
+
+    _apply_frequency_scale(ax, spacing_type)
+    ax.set_title("Live Measurement Trajectory")
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel("Phase (rad)")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right")
+    fig.tight_layout()
+    return fig
+
+
+def _render_dual_panel_live_plot(data, spacing_type):
+    fig, (ax_top, ax_bottom) = plt.subplots(2, 1, figsize=(8, 9), sharex=False)
+
+    grouped = data.groupby("FrequencyIn")["PhaseOut"]
+    mean_phase = grouped.mean().sort_index()
+    std_phase = grouped.std().fillna(0).reindex(mean_phase.index)
+
+    ax_top.plot(mean_phase.index, mean_phase.values, color="#1f77b4", linewidth=2, label="Mean Phase")
+    ax_top.fill_between(
+        mean_phase.index,
+        (mean_phase - std_phase).values,
+        (mean_phase + std_phase).values,
+        color="#1f77b4",
+        alpha=0.2,
+        label="±1 Std",
+    )
+    _apply_frequency_scale(ax_top, spacing_type)
+    ax_top.set_title("Frequency Response")
+    ax_top.set_xlabel("Frequency (Hz)")
+    ax_top.set_ylabel("Phase (rad)")
+    ax_top.grid(True, alpha=0.3)
+    ax_top.legend(loc="upper right")
+
+    recent_count = min(40, len(data))
+    recent_data = data.tail(recent_count).copy()
+    recent_data["Time"] = pd.to_datetime(recent_data["Time"], errors="coerce")
+    if recent_data["Time"].notna().all():
+        x_vals = recent_data["Time"]
+        ax_bottom.set_xlabel("Time")
+    else:
+        x_vals = np.arange(recent_count)
+        ax_bottom.set_xlabel("Recent Sample Index")
+
+    ax_bottom.plot(x_vals, recent_data["PhaseOut"], color="#ff7f0e", linewidth=1.8, label="Recent Phase")
+    ax_bottom.scatter(x_vals.iloc[-1] if hasattr(x_vals, "iloc") else x_vals[-1], recent_data["PhaseOut"].iloc[-1],
+                      color="#d62728", s=70, label="Latest")
+    ax_bottom.set_title("Recent Drift / Settling")
+    ax_bottom.set_ylabel("Phase (rad)")
+    ax_bottom.grid(True, alpha=0.3)
+    ax_bottom.legend(loc="upper right")
+
+    fig.tight_layout()
+    return fig
+
+
+PLOT_RENDERERS = {
+    "Default": _render_default_plot,
+    "Candlestick": _render_candlestick_plot,
+    "TrendLive": _render_trend_live_plot,
+    "TrajectoryLive": _render_trajectory_live_plot,
+    "DualPanelLive": _render_dual_panel_live_plot,
+}
 
 
 def plotting_process(data_queue, plot_queue, plot_code="Default"):
@@ -179,10 +300,8 @@ def plotting_process(data_queue, plot_queue, plot_code="Default"):
                 break
 
             data, spacing_type = _prepare_data(payload)
-            if selected_plot == "Candlestick":
-                fig = _render_candlestick_plot(data, spacing_type)
-            else:
-                fig = _render_default_plot(data, spacing_type)
+            renderer = PLOT_RENDERERS.get(selected_plot, _render_default_plot)
+            fig = renderer(data, spacing_type)
 
             image = _figure_to_image(fig)
             plot_queue.put_nowait(image)

--- a/src/gui_tabs/graph_box.py
+++ b/src/gui_tabs/graph_box.py
@@ -191,7 +191,7 @@ def _render_trend_live_plot(data, spacing_type):
         q3.values,
         color="#d62728",
         alpha=0.2,
-        label="Interquartile Range (25th-75th Percentile)",
+        label="Interquartile Range",
     )
 
     latest = data.iloc[-1]

--- a/src/gui_tabs/graph_box.py
+++ b/src/gui_tabs/graph_box.py
@@ -173,6 +173,7 @@ def _render_candlestick_plot(data, spacing_type):
 def _render_trend_live_plot(data, spacing_type):
     fig = plt.figure(figsize=(8, 8))
     ax = fig.gca()
+    ax_ri = ax.twinx()
 
     grouped = data.groupby("FrequencyIn")["PhaseOut"]
     median_phase = grouped.median().sort_index()
@@ -200,34 +201,47 @@ def _render_trend_live_plot(data, spacing_type):
         zorder=3,
     )
 
+    real_line = None
+    imag_line = None
+
     if "RealOut" in data.columns:
         real_median = data.groupby("FrequencyIn")["RealOut"].median().reindex(median_phase.index)
-        ax.plot(
+        real_line, = ax_ri.plot(
             real_median.index,
             real_median.values,
             color="#00cfe8",
             linewidth=1.7,
             alpha=0.6,
-            label="Median RealOut",
+            label="Median RealOut (right axis)",
         )
 
     if "ImagOut" in data.columns:
         imag_median = data.groupby("FrequencyIn")["ImagOut"].median().reindex(median_phase.index)
-        ax.plot(
+        imag_line, = ax_ri.plot(
             imag_median.index,
             imag_median.values,
             color="#ff8c00",
             linewidth=1.7,
             alpha=0.6,
-            label="Median ImagOut",
+            label="Median ImagOut (right axis)",
         )
 
     _apply_frequency_scale(ax, spacing_type)
+    _apply_frequency_scale(ax_ri, spacing_type)
     ax.set_title("Live Phase Trend with IQR Band")
     ax.set_xlabel("Frequency (Hz)")
     ax.set_ylabel("Phase (rad)")
+    ax_ri.set_ylabel("Real / Imag (V)")
+    ax_ri.tick_params(axis="y", labelcolor="#444444")
     ax.grid(True, alpha=0.3)
-    ax.legend(loc="upper right")
+    handles, labels = ax.get_legend_handles_labels()
+    if real_line is not None:
+        handles.append(real_line)
+        labels.append("Median RealOut (right axis)")
+    if imag_line is not None:
+        handles.append(imag_line)
+        labels.append("Median ImagOut (right axis)")
+    ax.legend(handles, labels, loc="upper right")
     fig.tight_layout()
     return fig
 

--- a/src/gui_tabs/graph_box.py
+++ b/src/gui_tabs/graph_box.py
@@ -9,9 +9,9 @@ from PIL import Image
 
 
 SUPPORTED_PLOTS = {
-    "Default",
-    "Candlestick",
     "TrendLive",
+    "Legacy",
+    "Candlestick",
     "TrajectoryLive",
     "DualPanelLive",
 }
@@ -180,7 +180,14 @@ def _render_trend_live_plot(data, spacing_type):
     q3 = grouped.quantile(0.75).reindex(median_phase.index)
 
     ax.plot(median_phase.index, median_phase.values, color="#1f77b4", linewidth=2, label="Median Phase")
-    ax.fill_between(median_phase.index, q1.values, q3.values, color="#1f77b4", alpha=0.2, label="IQR (25-75%)")
+    ax.fill_between(
+        median_phase.index,
+        q1.values,
+        q3.values,
+        color="#d62728",
+        alpha=0.2,
+        label="Interquartile Range (25th-75th Percentile)",
+    )
 
     latest = data.iloc[-1]
     ax.scatter(
@@ -192,6 +199,28 @@ def _render_trend_live_plot(data, spacing_type):
         label="Latest Measurement",
         zorder=3,
     )
+
+    if "RealOut" in data.columns:
+        real_median = data.groupby("FrequencyIn")["RealOut"].median().reindex(median_phase.index)
+        ax.plot(
+            real_median.index,
+            real_median.values,
+            color="#00cfe8",
+            linewidth=1.7,
+            alpha=0.6,
+            label="Median RealOut",
+        )
+
+    if "ImagOut" in data.columns:
+        imag_median = data.groupby("FrequencyIn")["ImagOut"].median().reindex(median_phase.index)
+        ax.plot(
+            imag_median.index,
+            imag_median.values,
+            color="#ff8c00",
+            linewidth=1.7,
+            alpha=0.6,
+            label="Median ImagOut",
+        )
 
     _apply_frequency_scale(ax, spacing_type)
     ax.set_title("Live Phase Trend with IQR Band")
@@ -280,17 +309,17 @@ def _render_dual_panel_live_plot(data, spacing_type):
 
 
 PLOT_RENDERERS = {
-    "Default": _render_default_plot,
-    "Candlestick": _render_candlestick_plot,
     "TrendLive": _render_trend_live_plot,
+    "Legacy": _render_default_plot,
+    "Candlestick": _render_candlestick_plot,
     "TrajectoryLive": _render_trajectory_live_plot,
     "DualPanelLive": _render_dual_panel_live_plot,
 }
 
 
-def plotting_process(data_queue, plot_queue, plot_code="Default"):
+def plotting_process(data_queue, plot_queue, plot_code="TrendLive"):
     print("Starting plotting process")
-    selected_plot = plot_code if plot_code in SUPPORTED_PLOTS else "Default"
+    selected_plot = plot_code if plot_code in SUPPORTED_PLOTS else "TrendLive"
 
     while True:
         try:
@@ -300,7 +329,7 @@ def plotting_process(data_queue, plot_queue, plot_code="Default"):
                 break
 
             data, spacing_type = _prepare_data(payload)
-            renderer = PLOT_RENDERERS.get(selected_plot, _render_default_plot)
+            renderer = PLOT_RENDERERS.get(selected_plot, _render_trend_live_plot)
             fig = renderer(data, spacing_type)
 
             image = _figure_to_image(fig)

--- a/src/gui_tabs/graph_box.py
+++ b/src/gui_tabs/graph_box.py
@@ -7,6 +7,10 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from PIL import Image
 
+REAL_TRACE_COLOR = "#00cfe8"
+IMAG_TRACE_COLOR = "#ff8c00"
+TRACE_ALPHA = 0.45
+
 
 SUPPORTED_PLOTS = {
     "TrendLive",
@@ -209,9 +213,9 @@ def _render_trend_live_plot(data, spacing_type):
         real_line, = ax_ri.plot(
             real_median.index,
             real_median.values,
-            color="#00cfe8",
+            color=REAL_TRACE_COLOR,
             linewidth=1.7,
-            alpha=0.6,
+            alpha=TRACE_ALPHA,
             label="Median RealOut (right axis)",
         )
 
@@ -220,9 +224,9 @@ def _render_trend_live_plot(data, spacing_type):
         imag_line, = ax_ri.plot(
             imag_median.index,
             imag_median.values,
-            color="#ff8c00",
+            color=IMAG_TRACE_COLOR,
             linewidth=1.7,
-            alpha=0.6,
+            alpha=TRACE_ALPHA,
             label="Median ImagOut (right axis)",
         )
 

--- a/src/gui_tabs/graph_box.py
+++ b/src/gui_tabs/graph_box.py
@@ -1,239 +1,228 @@
 import multiprocessing as mp
-import queue
-import os
 import traceback
 from io import BytesIO
-import pandas
-from matplotlib import pyplot as plt
+
 import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
 from PIL import Image
 
-PICKLE_FILE_LOCATION = "./temp"
+
+SUPPORTED_PLOTS = {"Default", "Candlestick"}
 
 
-def standard_graph(data_queue, plot_queue):
+def _prepare_data(payload):
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        spacing = payload.get("spacing", "linspace")
+        if data is None:
+            raise ValueError("Missing dataframe in plot payload")
+        return data, spacing
+
+    if isinstance(payload, str):
+        data = pd.read_pickle(payload)
+        spacing = payload.split("_")[-1].split(".")[0]
+        return data, spacing
+
+    raise ValueError(f"Unsupported plot payload type: {type(payload)}")
+
+
+def _figure_to_image(fig):
+    buf = BytesIO()
+    fig.savefig(buf, format="png")
+    buf.seek(0)
+    image = Image.open(buf).copy()
+    buf.close()
+    return image
+
+
+def _render_default_plot(data, spacing_type):
+    fig = plt.figure(figsize=(8, 8))
+    ax1 = fig.gca()
+    ax2 = ax1.twinx()
+
+    last_measurements = data.groupby("FrequencyIn").last()
+    mean_phases = data.groupby("FrequencyIn")["PhaseOut"].mean()
+
+    last_scatter = ax1.scatter(
+        last_measurements.index,
+        last_measurements["PhaseOut"],
+        marker="o",
+        s=100,
+        c="red",
+        alpha=0.75,
+    )
+    mean_scatter = ax1.scatter(
+        mean_phases.index,
+        mean_phases,
+        marker="o",
+        s=100,
+        c="blue",
+        alpha=0.5,
+    )
+
+    ax1.legend(
+        [last_scatter, mean_scatter],
+        ["Red: Most Recent Phase", "Blue: Average Phase"],
+        loc="upper right",
+    )
+    ax1.set_xlabel("Frequency (Hz)")
+    ax1.set_ylabel("Phase (rad)", color="blue")
+    ax2.set_ylabel("Diffusivity", color="green")
+
+    if spacing_type == "logspace":
+        ax1.set_xscale("log")
+
+    ax1.set_title("Phase and Diffusivity vs Frequency")
+    ax1.grid(True)
+    ax1.tick_params(axis="y", labelcolor="blue")
+    ax2.tick_params(axis="y", labelcolor="green")
+    fig.tight_layout()
+
+    return fig
+
+
+def _render_candlestick_plot(data, spacing_type):
+    fig = plt.figure(figsize=(8, 8))
+    ax = fig.gca()
+
+    if "Convergence" in data.columns:
+        converged_data = data[data["Convergence"] == True]
+        if converged_data.empty:
+            ax.set_title("No converged points yet")
+            ax.set_xlabel("Frequency (Hz)")
+            ax.set_ylabel("Phase (rad)")
+            ax.grid(True)
+            return fig
+    else:
+        converged_data = data
+
+    grouped = converged_data.groupby("FrequencyIn")["PhaseOut"]
+
+    opens = grouped.first()
+    closes = grouped.last()
+    highs = grouped.max()
+    lows = grouped.min()
+
+    frequencies = opens.index.to_numpy(dtype=float)
+    if len(frequencies) == 0:
+        ax.set_title("No data available")
+        ax.set_xlabel("Frequency (Hz)")
+        ax.set_ylabel("Phase (rad)")
+        ax.grid(True)
+        return fig
+
+    if len(frequencies) > 1:
+        widths = np.diff(np.sort(frequencies)) * 0.6
+        candle_width = float(np.min(widths))
+    else:
+        candle_width = max(abs(frequencies[0]) * 0.05, 1.0)
+
+    up_color = "#2ca02c"
+    down_color = "#d62728"
+
+    for freq in frequencies:
+        open_val = float(opens.loc[freq])
+        close_val = float(closes.loc[freq])
+        high_val = float(highs.loc[freq])
+        low_val = float(lows.loc[freq])
+
+        color = up_color if close_val >= open_val else down_color
+
+        ax.vlines(freq, low_val, high_val, color=color, linewidth=1.5, zorder=1)
+
+        body_bottom = min(open_val, close_val)
+        body_height = abs(close_val - open_val)
+        if body_height == 0:
+            body_height = 1e-9
+
+        rect = plt.Rectangle(
+            (freq - candle_width / 2, body_bottom),
+            candle_width,
+            body_height,
+            facecolor=color,
+            edgecolor=color,
+            alpha=0.7,
+            zorder=2,
+        )
+        ax.add_patch(rect)
+
+    up_proxy = plt.Line2D([0], [0], color=up_color, lw=6)
+    down_proxy = plt.Line2D([0], [0], color=down_color, lw=6)
+    ax.legend(
+        [up_proxy, down_proxy],
+        ["Green: Close >= Open", "Red: Close < Open"],
+        loc="upper right",
+    )
+
+    if spacing_type == "logspace":
+        ax.set_xscale("log")
+
+    ax.set_title("Candlestick Phase vs Frequency")
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel("Phase (rad)")
+    ax.grid(True)
+    fig.tight_layout()
+
+    return fig
+
+
+def plotting_process(data_queue, plot_queue, plot_code="Default"):
+    print("Starting plotting process")
+    selected_plot = plot_code if plot_code in SUPPORTED_PLOTS else "Default"
+
     while True:
         try:
-            if data_queue.empty():
-                continue
-
-            file_location = data_queue.get()
-            print(f"Standard graph received file location: {file_location}")
-
-            if file_location is None:
+            payload = data_queue.get()
+            if payload is None:
                 print("Received exit signal")
                 break
 
-            spacing_type = file_location.split("_")[-1].split(".")[0]
-            print(f"Detected spacing type: {spacing_type}")
+            data, spacing_type = _prepare_data(payload)
+            if selected_plot == "Candlestick":
+                fig = _render_candlestick_plot(data, spacing_type)
+            else:
+                fig = _render_default_plot(data, spacing_type)
 
-            try:
-                data = pandas.read_pickle(file_location)
-                print(f"Successfully read data with columns: {data.columns}")
-            except Exception as e:
-                print(f"Error reading pickle file: {e}")
-                continue
-
-            plt.clf()
-            fig = plt.figure(figsize=(8, 8))
-            ax1 = fig.gca()
-            ax2 = ax1.twinx()
-
-            # Plot phase measurements on left axis
-            last_measurements = data.groupby('FrequencyIn').last()
-            last_scatter = ax1.scatter(last_measurements.index,
-                                     last_measurements['PhaseOut'],
-                                     marker='o',
-                                     s=100,
-                                     c='Red',
-                                     alpha=0.75)
-
-            average_frequencies = data.groupby('FrequencyIn')
-            mean_phases = average_frequencies['PhaseOut'].mean()
-            mean_scatter = ax1.scatter(mean_phases.index,
-                                     mean_phases,
-                                     marker='o',
-                                     s=100,
-                                     c='Blue',
-                                     alpha=0.5)
-
-            # # # Plot diffusivity on right axis
-            # # filtered_data = data[data['DiffusivityEstimate'].apply(lambda x: isinstance(x, float) and not np.isnan(x))]
-            # # if not filtered_data.empty:
-            # #     diff_data = filtered_data.groupby('FrequencyIn')['DiffusivityEstimate'].last()
-            # #     barGraph = ax2.bar(diff_data.index, 
-            # #                      diff_data.values, 
-            # #                      alpha=0.3,
-            # #                      color='green',
-            # #                      zorder=2,
-            # #                      width=(ax1.get_xlim()[1] - ax1.get_xlim()[0])*(1/(len(diff_data)+1)))
-                
-            # #     # Combine legends from both axes
-            # #     ax1.legend([last_scatter, mean_scatter, barGraph], 
-            # #              ['Most Recent Phase', 'Average Phase', 'Diffusivity Estimate'])
-            # else:
-            #     ax1.legend([last_scatter, mean_scatter], 
-            #              ['Most Recent Phase', 'Average Phase'])
-
-            # Set labels
-            ax1.set_xlabel('Frequency (Hz)')
-            ax1.set_ylabel('Phase (rad)', color='blue')
-            ax2.set_ylabel('Diffusivity', color='green')
-
-            # Set scales
-            if spacing_type == "logspace":
-                ax1.set_xscale('log')
-
-            plt.title('Phase and Diffusivity vs Frequency')
-            ax1.grid(True)
-
-            # Adjust colors of tick labels to match their data
-            ax1.tick_params(axis='y', labelcolor='blue')
-            ax2.tick_params(axis='y', labelcolor='green')
-
-            plt.tight_layout()
-
-            buf = BytesIO()
-            plt.savefig(buf, format='png')
-            buf.seek(0)
-
-            image = Image.open(buf)
-            plot_queue.put_nowait(image.copy())
-
-            buf.close()
+            image = _figure_to_image(fig)
+            plot_queue.put_nowait(image)
             plt.close(fig)
-
         except Exception as e:
             print(f"Error in plotting process: {e}")
             print(traceback.format_exc())
 
 
-def candlestick_graph(data_queue, plot_queue):
-    while True:
-        try:
-            file_location = data_queue.get()
-            print(f"Candlestick graph received file location: {file_location}")
-
-            if file_location is None:
-                print("Received exit signal")
-                break  # Exit signal
-
-            # Clear any existing plots and create a new figure
-            plt.clf()
-            fig = plt.figure(figsize=(8, 8))
-
-            print(f"Attempting to read pickle file from: {file_location}")
-            data = pandas.read_pickle(file_location)
-            print(f"Successfully read pickle file. Data columns: {data.columns}")
-
-            if 'Convergence' in data.columns:
-                converged_data = data[data['Convergence'] == True]
-                if len(converged_data) == 0:
-                    print("No converged data points found")
-                    continue
-            else:
-                print("No convergence data found in dataset")
-                converged_data = data
-
-            grouped = converged_data.groupby('FrequencyIn')['PhaseOut']
-            mean_phase = grouped.mean()
-            std_phase = grouped.std()
-
-            frequencies = mean_phase.index
-
-            sample_size = grouped.count()
-
-            plt.errorbar(frequencies, mean_phase, yerr=std_phase, fmt='none')
-
-            # Plot colored points with sample size mapped to color
-            sc = plt.scatter(frequencies, mean_phase, c=sample_size, cmap='gist_rainbow', zorder=2)
-            plt.colorbar(sc, label='Sample Size')
-
-            plt.title('Phase vs Frequency (Error bars)')
-            plt.xlabel('Frequency (Hz)')
-            plt.ylabel('Phase (rad)')
-            plt.grid(True)
-
-            print("Saving plot to buffer...")
-            buf = BytesIO()
-            plt.savefig(buf, format='png')
-            buf.seek(0)
-
-            print("Creating image from buffer...")
-            image = Image.open(buf)
-            print("Attempting to put image in queue...")
-            plot_queue.put_nowait(image.copy())
-            print("Successfully queued new image")
-
-            buf.close()
-            plt.close(fig)
-
-        except Exception as e:
-            print(f"Error in candlestick plotting process: {e}")
-            print(f"Error type: {type(e)}")
-            import traceback
-            print(traceback.format_exc())
-
-
-def plotting_process(data_queue, plot_queue, plot_code = "Default"):
-    """Separate process function for plotting"""
-    print("Starting plotting process")
-    print(f"Plot code Type: {type(plot_code)}")
-    print(f"Plot code: {plot_code}")
-    if plot_code == "Default":
-        standard_graph(data_queue, plot_queue)
-    elif plot_code == "Candlestick":
-        candlestick_graph(data_queue, plot_queue)
-    else:
-        print("Invalid plot code")
-
-
 class GraphBox:
     def __init__(self, distance, plot_code):
-        self.PICKLE_FILE_LOCATION = PICKLE_FILE_LOCATION
         self.laser_distance = distance
-        # Regular lists for data storage in main thread
         self.amplitude_data = []
         self.phase_data = []
         self.step_data = []
         self.frequency_data = []
         self.diffusivity_estimates = []
 
-        # Create a process-safe queue for plotting
-        self.data_queue = mp.Queue() # Getting data
-        self.plot_output = mp.Queue() # Sending finished plots
+        self.data_queue = mp.Queue()
+        self.plot_output = mp.Queue()
 
-        # Start the plotting process
         self.plot_process = mp.Process(
             target=plotting_process,
             args=(self.data_queue, self.plot_output, plot_code),
-            daemon=True
+            daemon=True,
         )
         self.plot_process.start()
 
+    def queue_plot_update(self, data, spacing_type):
+        self.data_queue.put_nowait({"data": data, "spacing": spacing_type})
+
     def close_plotting_process(self):
-        """Close the plotting process"""
         self.data_queue.put(None)
 
     @staticmethod
     def clear_graph():
-        """Clear existing graph file and data"""
-        # Clear the existing graph file if it exists
-        plots_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'plots')
-        if os.path.exists(plots_dir):
-            temp_file = os.path.join(plots_dir, "temp.png")
-            if os.path.exists(temp_file):
-                try:
-                    os.remove(temp_file)
-                except Exception as e:
-                    print(f"Error removing old graph: {e}")
+        return
 
     def update_graph(self, data):
-        print(f"Sending pickled data location to plotter: {PICKLE_FILE_LOCATION}")
-        # Send pickled data location to plotting process
-        pandas.to_pickle(data, PICKLE_FILE_LOCATION)
-        self.data_queue.put(PICKLE_FILE_LOCATION)
-
+        self.queue_plot_update(data, "linspace")
 
     def instantaneous_diffusivity(self):
         try:
@@ -250,10 +239,9 @@ class GraphBox:
         return (1 / slope ** 2) * 1000000
 
     def __del__(self):
-        # Cleanup: send exit signal to plotting process
-        if hasattr(self, 'data_queue'):
+        if hasattr(self, "data_queue"):
             self.data_queue.put(None)
-        if hasattr(self, 'plot_process'):
+        if hasattr(self, "plot_process"):
             self.plot_process.join(timeout=1.0)
             if self.plot_process.is_alive():
                 self.plot_process.terminate()


### PR DESCRIPTION
This pull request updates the `AutomationTab` in `automationLaserTab.py` to improve the user interface, streamline measurement control logic, and enhance graphing options. The most notable changes include refactoring the measurement control state management, expanding graph selection options, and simplifying how plot updates are handled.

**User Interface and Control Improvements:**

* Introduced a new `_set_measurement_controls` method to centralize and simplify enabling/disabling measurement-related buttons, replacing multiple scattered state assignments throughout the code. This method is now used when starting, ending, and completing automation. [[1]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babL249-L253) [[2]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babR258-R269) [[3]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babL292-R297) F628e92fL380)
* The automation completion state is now handled automatically: when automation finishes, the UI is reset and a completion message is inserted into the automation text box. (F628e92fL380)

**Graphing Enhancements:**

* The default graph type is changed from `"Default"` to `"TrendLive"`, and the graph selector now offers five options: `"TrendLive"`, `"Legacy"`, `"Candlestick"`, `"TrajectoryLive"`, and `"DualPanelLive"`. [[1]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babL23-R21) [[2]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babL141-R140)
* Updated the graph update mechanism to use a new `queue_plot_update` method, replacing manual pickling and queueing of data frames.

**Code Cleanup:**

* Removed unused imports (`multiprocessing`, redundant `pandas` import) and obsolete comments related to multiprocessing queues, reflecting a move away from multiprocessing for image handling. [[1]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babL4-L10) [[2]](diffhunk://#diff-b0b018816207b55eab86ebeaca9e4d1195aef1827757150867962be5352e1babL218-L219)