### PR TITLE
Remove unused GUI controls

### DIFF
--- a/src/automationManager.py
+++ b/src/automationManager.py
@@ -341,7 +341,6 @@ class AutomationManager:
 
         # Everything below here should be the main loop
         for i in range(len(hexapod_rotation_stepList)):
-            self.parent.automation_progress_bar = (i / len(hexapod_rotation_stepList)) * 100  # Update the progress bar
             theta = hexapod_rotation_stepList[i] - hexapod_rotation_stepList[i - 1]
             rotation_vector = np.array([0, 0, theta])
             self.hexapod.rotate(rotation_vector)

--- a/src/gui_tabs/automationHexapodTab.py
+++ b/src/gui_tabs/automationHexapodTab.py
@@ -44,52 +44,6 @@ class HexapodAutomationTab:
         debugging_frame = ttk.LabelFrame(hexapod_automation_tab, text="Debugging Stuff")
         debugging_frame.grid(row=4, column=0, columnspan=5, padx=10, pady=5, sticky='nsew')
 
-        # Add new constraints frame
-        constraints_frame = ttk.LabelFrame(hexapod_automation_tab, text="Movement Constraints")
-        constraints_frame.grid(row=3, column=0, columnspan=5, padx=10, pady=5, sticky='nsew')
-
-        # Create a subframe for the meters to control their size and layout
-        meters_frame = ttk.Frame(constraints_frame)
-        meters_frame.grid(row=0, column=0, columnspan=6, padx=5, pady=5)
-
-        # Define coordinate systems with their ranges
-        coordinates = {
-            'X': {'name': 'X Position', 'range': (-30, 30)},  # ±50mm
-            'Y': {'name': 'Y Position', 'range': (-30, 30)},  # ±50mm
-            'Z': {'name': 'Z Position', 'range': (-20, 20)},  # ±25mm
-            'Roll (Rx)': {'name': 'Roll', 'range': (-11, 11)},     # ±20°
-            'Pitch (Ry)': {'name': 'Pitch', 'range': (-11, 11)},   # ±20°
-            'Yaw (Rz)': {'name': 'Yaw', 'range': (-20, 20)}        # ±20°
-        }
-
-        self.constraint_meters = {}
-
-        for i, (coord, info) in enumerate(coordinates.items()):
-            # Create frame for each meter
-            meter_frame = ttk.LabelFrame(meters_frame, text=info['name'])
-            meter_frame.grid(row=i//3, column=i%3, padx=5, pady=5)
-
-            # Create meter with small size
-            meter = ttk.Meter(
-                meter_frame,
-                metersize=150,
-                padding=5,
-                amountused=50,  # Start at middle position
-                metertype="full",  # Full circle display
-                subtext=f"Range: {info['range'][0]} to {info['range'][1]}",
-                interactive=False,
-                stripethickness=10
-            )
-            meter.pack(padx=5, pady=5)
-
-            # Store meter reference
-            self.constraint_meters[coord] = {
-                'meter': meter,
-                'range': info['range']
-            }
-
-        # Method to update meter values
-
         # Status and Control Section
         self.hexapodStatusLabel = tk.Label(status_frame, text="Hexapod Status: Not Connected")
         self.hexapodStatusLabel.grid(row=0, column=0, columnspan=4, padx=10, pady=5)
@@ -131,17 +85,11 @@ class HexapodAutomationTab:
         self.degreesSweepInput = tk.Entry(movement_frame, textvariable=self.degrees_of_sweep)
         self.degreesSweepInput.grid(row=0, column=1, padx=10, pady=5)
 
-        self.pumpLaserDistanceLabel = tk.Label(movement_frame, text="Distance between lasers (mm)")
-        self.pumpLaserDistanceLabel.grid(row=1, column=0, padx=10, pady=5, sticky=tk.E)
-        self.pumpLaserDistanceInput = tk.Entry(movement_frame)
-        self.pumpLaserDistanceInput.insert(0, "1.0")
-        self.pumpLaserDistanceInput.grid(row=1, column=1, padx=10, pady=5)
-
         self.stepCountLabel = tk.Label(movement_frame, text="Step Count:")
         self.stepCount = tk.IntVar(movement_frame, 1)
         self.stepCountInput = tk.Entry(movement_frame, textvariable=self.stepCount, state='normal')
-        self.stepCountLabel.grid(row=2, column=0, padx=10, pady=5, sticky=tk.E)
-        self.stepCountInput.grid(row=2, column=1, padx=10, pady=5)
+        self.stepCountLabel.grid(row=1, column=0, padx=10, pady=5, sticky=tk.E)
+        self.stepCountInput.grid(row=1, column=1, padx=10, pady=5)
 
         # Output and Data Section
         file_frame = ttk.Frame(output_frame)
@@ -236,29 +184,6 @@ class HexapodAutomationTab:
         # Configure grid weights
         for frame in (status_frame, movement_frame, output_frame):
             frame.grid_columnconfigure(1, weight=1)
-
-    def update_meter_value(self, coordinate, pos_constraint, neg_constraint):
-        """
-        Update meter to show constraints in both positive and negative directions
-
-        Args:
-            coordinate: The coordinate to update ('X', 'Y', etc.)
-            pos_constraint: Constraint in positive direction (0-100%)
-            neg_constraint: Constraint in negative direction (0-100%)
-        """
-        meter = self.constraint_meters[coordinate]['meter']
-        total_range = abs(self.constraint_meters[coordinate]['range'][1] -
-                          self.constraint_meters[coordinate]['range'][0])
-
-        # Calculate the amount used based on constraints
-        pos_amount = (100 - pos_constraint) * (total_range / 2) / 100
-        neg_amount = (100 - neg_constraint) * (total_range / 2) / 100
-
-        # Update meter display
-        meter.configure(
-            amountused=(pos_amount + neg_amount) / total_range * 100,
-            sublabel=f"+{pos_amount:.1f}/-{neg_amount:.1f}"
-        )
 
     def print_hexapod_state(self):
         def actually_print():

--- a/src/gui_tabs/automationManagementTab.py
+++ b/src/gui_tabs/automationManagementTab.py
@@ -10,15 +10,11 @@ class AutomationManagerTab:
         self.instruments = instruments
         self.manager = automationManager.AutomationManager(self, instruments, None, main_gui)
         self.setup_ui()
-        self.automation_progress = 0
 
     def setup_ui(self):
     # Create main frames
         control_frame = ttk.LabelFrame(self.parent, text="Automation Control")
-        control_frame.grid(row=0, column=0, columnspan=6, padx=10, pady=5, sticky='nsew')
-
-        status_frame = ttk.LabelFrame(self.parent, text="Automation Status")
-        status_frame.grid(row=1, column=0, columnspan=6, padx=10, pady=5, sticky='nsew')
+        control_frame.grid(row=0, column=0, columnspan=4, padx=10, pady=5, sticky='nsew')
 
         # Automation Control Section
         laser_frame = ttk.LabelFrame(control_frame, text="Laser Control")
@@ -28,10 +24,6 @@ class AutomationManagerTab:
                                             command=self.start_automation, state=tk.DISABLED)
         self.startAutomationButton.grid(row=0, column=0, padx=5, pady=5)
 
-        self.stopAutomationButton = tk.Button(laser_frame, text="Stop Automation", 
-                                            command=self.stop_automation)
-        self.stopAutomationButton.grid(row=0, column=1, padx=5, pady=5)
-
         focusing_frame = ttk.LabelFrame(control_frame, text="Focusing Control")
         focusing_frame.grid(row=0, column=2, columnspan=2, padx=5, pady=5, sticky='nsew')
 
@@ -39,89 +31,17 @@ class AutomationManagerTab:
                                             command=self.runFocussingCycle, state=tk.DISABLED)
         self.startFocussingButton.grid(row=0, column=0, padx=5, pady=5)
 
-        self.stopFocussingButton = tk.Button(focusing_frame, text="Stop Focussing", 
-                                        command=self.endFocussing)
-        self.stopFocussingButton.grid(row=0, column=1, padx=5, pady=5)
-
-        system_frame = ttk.LabelFrame(control_frame, text="System Control")
-        system_frame.grid(row=0, column=4, columnspan=2, padx=5, pady=5, sticky='nsew')
-
-        self.checkConnectionButton = tk.Button(system_frame, text="Check Connections", 
-                                            command=lambda: self.check_connections(
-                                                self.parent.laserTabObject, 
-                                                self.parent.hexapodTabObject))
-        self.checkConnectionButton.grid(row=0, column=0, padx=5, pady=5)
-
-        # Status Section
-        self.progress_label = ttk.Label(status_frame, text="Automation Progress: 0.0%")
-        self.progress_label.grid(row=0, column=0, padx=5, pady=2, sticky='w')
-
-        self.progress_bar = ttk.Progressbar(status_frame, orient="horizontal", 
-                                        length=300, mode="determinate")
-        self.progress_bar.grid(row=1, column=0, columnspan=6, padx=5, pady=2, sticky='ew')
-        
-        # Set initial progress value to 50%
-        self.progress_bar['value'] = 50
-
         # Configure grid weights
         self.parent.grid_columnconfigure(0, weight=1)
-        for frame in (control_frame, status_frame):
-            frame.grid_columnconfigure(0, weight=1)
-        
-
-    def update_progress(self):
-        """
-        Updates the progress bar and schedules the next update.
-        Called every 100ms to update the progress display.
-        """
-        # Add progress value update logic here
-        try:
-            # The progress value should be between 0 and 100
-            current_progress = self.automation_progress
-            self.progress_bar['value'] = current_progress
-
-            # Update progress label with percentage
-            progress_text = f"Automation Progress: {current_progress:.1f}%"
-            self.progress_label.configure(text=progress_text)
-
-        except Exception as e:
-            print(f"Error updating progress: {e}")
-
-        # Schedule next update in 100ms
-        self.parent.after(100, self.update_progress)
-
-    def start_progress_updates(self):
-        """
-        Starts the progress update loop
-        """
-        self.update_progress()
-
-    def stop_progress_updates(self):
-        """
-        Resets the progress bar to 0
-        """
-        self.progress_bar['value'] = 0
-        self.progress_label.configure(text="Automation Progress: 0.0%")
-
-
-    def check_connections(self, laserGUI, hexapodGUI):
-        self.manager.checkConnections(laserGUI, hexapodGUI)
+        control_frame.grid_columnconfigure(0, weight=1)
 
     def start_automation(self):
         self.manager.beginAutomation()
-        self.start_progress_updates()
 
     def update_hexapod_command_controls(self, ready):
         state = tk.NORMAL if ready else tk.DISABLED
         self.startAutomationButton.configure(state=state)
         self.startFocussingButton.configure(state=state)
 
-    def stop_automation(self):
-        self.manager.endAutomation()
-        self.stop_progress_updates()
-    
     def runFocussingCycle(self):
         self.manager.runFocussingCycle()
-
-    def endFocussing(self):
-        self.manager.endFocussing()

--- a/src/microscopeGUI.py
+++ b/src/microscopeGUI.py
@@ -46,7 +46,6 @@ class MicroscopeGUI:
         # Create frames for each tab
         laserAutomationFrame = ttk.Frame(notebook)
         hexapodAutomationFrame = ttk.Frame(notebook)
-        sampleMappingFrame = ttk.Frame(notebook)
         generalAutomationFrame = ttk.Frame(notebook)
         rasteringFrame = ttk.Frame(notebook)
         cameraControlFrame = ttk.Frame(notebook)
@@ -54,7 +53,6 @@ class MicroscopeGUI:
         # Add frames to notebook
         notebook.add(laserAutomationFrame, text='Laser Automation')
         notebook.add(hexapodAutomationFrame, text='Hexapod Automation')
-        notebook.add(sampleMappingFrame, text='Sample Mapping')
         notebook.add(generalAutomationFrame, text='Automation Finalization')
         notebook.add(rasteringFrame, text='Rastering')
         notebook.add(cameraControlFrame, text='Camera Control')
@@ -65,9 +63,6 @@ class MicroscopeGUI:
 
         self.hexapodTabObject = automationHexapodTab.HexapodAutomationTab(hexapodAutomationFrame, self.instruments, self)
         
-        #TODO: Implement Sample Mapping Tab
-        #self.sampleMappingTabObject = sampleMappingTab.SampleMappingTab(sampleMappingFrame, self.instruments, self.hexapodTabObject)
-
         self.automationTabObject = automationManagementTab.AutomationManagerTab(generalAutomationFrame, self.instruments, self)
 
         self.rasteringTabObject = rasteringTab.RasteringTab(rasteringFrame, self.instruments, self)


### PR DESCRIPTION
## Summary
- remove static hexapod constraint meters and the unused laser-distance input
- remove the blank Sample Mapping tab
- remove broken automation check, stop, and progress controls
- preserve the identified secondary clutter for separate follow-up

## Testing
- python -m unittest discover -s tests
- python -m py_compile src/gui_tabs/automationHexapodTab.py src/gui_tabs/automationManagementTab.py src/microscopeGUI.py src/automationManager.py